### PR TITLE
ec2 Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ yarn.lock
 .DS_Store
 .env
 config/full_node.json
+
+*.pem

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 > `cp config/full_node.example.json config/full_node.json`
 > Then update the private values
 
+ec2 instance :: `3.14.153.125` ([status check](https://semicolonfingers.com/rollup-status))
+
 ## Local Dev
 
 ```


### PR DESCRIPTION
> closes #4

Chain and caff-node running on ec2 instance: 3.14.153.125

Currently, the ports are open to all, but need to restrict access to vercel server only. See https://github.com/thisispalash/semicolonfingers/issues/11 for more information.